### PR TITLE
Fixed typescript error

### DIFF
--- a/src/components/hocs/withPagination.tsx
+++ b/src/components/hocs/withPagination.tsx
@@ -8,7 +8,7 @@ export type WithPaginationProps = {
 }
 
 const withPagination =
-  <P extends unknown>(
+  <P extends {}>(
     Component: (props: P & WithPaginationProps) => JSX.Element,
     initialStep: number = 1
   ) =>


### PR DESCRIPTION
Hey!

Trying to follow your repository I've seen that extending unknown gives a small typescript error while spreading the props.

We know that props it's an object so extending the generic to objects fix the error.

<img width="582" alt="Captura de Pantalla 2022-09-16 a las 12 55 27" src="https://user-images.githubusercontent.com/65885753/190623807-f0a438c1-4ac8-4978-b9cc-2c38da60afe3.png">


